### PR TITLE
Update deno-azd-template README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,26 @@ The following prerequisites are required to use this application. Please ensure 
 The fastest way for you to get this application up and running on Azure is to use the `azd up` command. This single command will create and configure all necessary Azure resources - including access policies and roles for your account and service-to-service communication with Managed Identities.
 
 1. Open a terminal, create a new empty folder, and change into it.
-1. Create a new [Python virtual environment](https://docs.python.org/3/library/venv.html).
-1. Run the following command to initialize the project, provision Azure resources, and deploy the application code.
+2. Create a new [Python virtual environment](https://docs.python.org/3/library/venv.html).
+3. Run the following command to initialize the project.
 
 ```bash
-azd up --template https://github.com/sjkp/deno-azd-template.git
+azd init --template https://github.com/sjkp/deno-azd-template.git
 ```
 
-You will be prompted for the following information:
+This command will clone the code to your current folder and prompt you for the following information:
 
 - `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
+
+4. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+
+```bash
+azd up
+```
+
+This command will prompt you for the following information:
+
 - `Azure Location`: The Azure location where your resources will be deployed.
-- `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
 > NOTE: This template may only be used with the following Azure locations:
 >
@@ -64,7 +72,11 @@ You will be prompted for the following information:
 >
 > If you attempt to use the template with an unsupported region, the provision step will fail.
 
-> NOTE: This may take a while to complete as it executes three commands: `azd init` (initializes environment), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it provisions and deploys your application.
+- `Azure Subscription`: The Azure Subscription where your resources will be deployed.
+
+
+
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
 
 When `azd up` is complete it will output the following URLs:
 
@@ -77,7 +89,7 @@ Click the web application URL to launch the Deno app. Create a new collection an
 > NOTE:
 >
 > - The `azd up` command will create Azure resources that will incur costs to your Azure subscription. You can clean up those resources manually via the Azure portal or with the `azd down` command.
-> - You can call `azd up` as many times as you like to both provision and deploy your solution, but you only need to provide the `--template` parameter the first time you call it to get the code locally. Subsequent `azd up` calls do not require the template parameter. If you do provide the parameter, all your local source code will be overwritten if you agree to overwrite when prompted.
+> - You can call `azd up` as many times as you like to both provision and deploy your solution.
 > - You can always create a new environment with `azd env new`.
 
 ### Application Architecture

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ This command will prompt you for the following information:
 
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
-
-
 > NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
 
 When `azd up` is complete it will output the following URLs:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This command will clone the code to your current folder and prompt you for the f
 
 - `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
 
-4. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+4. Run the following command to package a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the application code to those newly provisioned resources.
 
 ```bash
 azd up
@@ -74,7 +74,7 @@ This command will prompt you for the following information:
 
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
-> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (packages a deployable copy of your application), `azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
 
 When `azd up` is complete it will output the following URLs:
 


### PR DESCRIPTION
Update deno-azd-templateREADME to use `azd init` and `azd up` instead of `azd up --template` according to https://github.com/Azure/azure-dev/issues/1769.

@jongio, @rajeshkamal5050, @sjkp for notification.